### PR TITLE
Fixes maximum keyword length in Cargo.toml, changing 'configuration-language' to simply 'language'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "A lightweight, human-friendly configuration language parser & code generator"
 repository = "https://github.com/a1v0lut10n/colap.git"
 homepage = "https://github.com/a1v0lut10n/colap"
-keywords = ["configuration", "parser", "code-generator", "cola", "configuration-language"]
+keywords = ["configuration", "parser", "code-generator", "cola", "language"]
 categories = ["config", "command-line-utilities", "development-tools", "parsing", "parser-implementations"]
 
 [dependencies]


### PR DESCRIPTION
## Changes in this PR

This PR implements the **Bugfix/cargo Keyword Maxlength** feature.

## Commit History

 - **Fixes maximum keyword length in Cargo.toml, changing 'configuration-language' to simply 'language'**


## Checklist

- [ ] Documentation updated
- [ ] Tests added/updated
- [ ] Code reviewed


